### PR TITLE
emulator output path in dvs_text

### DIFF
--- a/v2e/emulator.py
+++ b/v2e/emulator.py
@@ -170,8 +170,8 @@ class EventEmulator(object):
                 logger.info('opening AEDAT-2.0 output file ' + path)
                 self.dvs_aedat2 = AEDat2Output(path)
             if dvs_text:
-                path = checkAddSuffix(path, '.txt')
                 path = os.path.join(self.output_folder, dvs_text)
+                path = checkAddSuffix(path, '.txt')
                 logger.info('opening text DVS output file ' + path)
                 self.dvs_text = DVSTextOutput(path)
         atexit.register(self.cleanup)


### PR DESCRIPTION
The following two lines were swapped [here](https://github.com/SensorsINI/v2e/blob/master/v2e/emulator.py#L173):
 ```
path = os.path.join(self.output_folder, dvs_text)
path = checkAddSuffix(path, '.txt')
```

I'm using your emulator for my research project. Really appreciate your work. Thank you!