### PR TITLE
Fixes installing issues with CoLab and python 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ setup(
     packages=find_packages(),
     url='https://github.com/SensorsINI/v2e',
     install_requires=[
-        'numpy==1.20',
+        'numpy==1.20; python_version<"3.10"',
+        'numpy>=1.21.2; python_version>="3.10"',
         'argcomplete',
         'engineering-notation', # not available on conda
         'tqdm',


### PR DESCRIPTION
Change Numpy Version for Python 3.10 and higher to match opencv-python minimal requirements