### PR TITLE
Fix installation errors with newer package versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ colored>=1.4.2
 cycler>=0.10.0
 decorator>=4.4.2
 defusedxml>=0.6.0
+dv-processing>=1.7.8
 engineering-notation>=0.6.0
 entrypoints>=0.3
 Gooey>=1.0.3.1
@@ -33,7 +34,7 @@ nbconvert>=5.6.1
 nbformat>=5.0.6
 notebook>=6.0.3
 numba>=0.49.1
-numpy>=1.21
+numpy<2.0 # require NumPy 1.x for dv-processing C extension compatibility
 olefile>=0.46
 opencv-python
 pandas>=1.0.3

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,8 @@ setup(
         'plyer',
         'screeninfo', # to get monitor sizes for cv2 window placement
         'easygui', # eacy open a file from no arg invocation
-        'scikit-image' # for some synthetic_input scripts
+        'scikit-image', # for some synthetic_input scripts
+	'dv_processing'
     ],
 
     scripts=['v2e.py', 'dataset_scripts/ddd/ddd_extract_data.py'],

--- a/v2e.py
+++ b/v2e.py
@@ -503,7 +503,7 @@ def main():
                     start_time, stop_time, (stop_time-start_time)))
 
         if exposure_mode == ExposureMode.DURATION:
-            dvsNumFrames = np.math.floor(
+            dvsNumFrames = np.floor(
                 dvsFps*srcDurationToBeProcessed/input_slowmotion_factor)
             dvsDuration = dvsNumFrames/dvsFps
             dvsPlaybackDuration = dvsNumFrames/avi_frame_rate

--- a/v2ecore/dataloader.py
+++ b/v2ecore/dataloader.py
@@ -60,7 +60,7 @@ class Frames(data.Dataset):
         for image in [self.array[index], self.array[index + 1]]:
             # Open image using pil.
             image = Image.fromarray(image)
-            image = image.resize(self.dim, Image.ANTIALIAS)
+            image = image.resize(self.dim, Image.LANCZOS)
             # Apply transformation if specified.
             if self.transform is not None:
                 image = self.transform(image)
@@ -139,7 +139,7 @@ class FramesDirectory(data.Dataset):
         for image in [image_1, image_2]:
             # Open image using pil.
             image = Image.fromarray(image)
-            image = image.resize(self.dim, Image.ANTIALIAS)
+            image = image.resize(self.dim, Image.LANCZOS)
             # Apply transformation if specified.
             if self.transform is not None:
                 image = self.transform(image)

--- a/v2ecore/slomo.py
+++ b/v2ecore/slomo.py
@@ -222,7 +222,7 @@ class SuperSloMo(object):
         # dict1 = torch.load(self.checkpoint, map_location='cpu')
         # fails intermittently on windows
 
-        dict1 = torch.load(self.checkpoint, map_location=self.device)
+        dict1 = torch.load(self.checkpoint, map_location=self.device, weights_only=False)
         interpolator.load_state_dict(dict1['state_dictAT'])
         flow_estimator.load_state_dict(dict1['state_dictFC'])
 


### PR DESCRIPTION
Fixes installation issues related to newer versions of NumPy, PyTorch, Pillow, and dv-processing

- Add `dv-processing` to `requirements.txt` and `setup.py`
- Pin `numpy<2.0` for C extension compatibility with dv-processing
- Replace `np.math.floor` with `np.floor`
- Use `weights_only=False` in PyTorch >=2.6
- Replace `Image.ANTIALIAS` (removed in Pillow >=10) with `Image.LANCZOS` 